### PR TITLE
fix: preprocessing

### DIFF
--- a/preprocessing/extract_facial_regions.py
+++ b/preprocessing/extract_facial_regions.py
@@ -33,8 +33,8 @@ def PatchExtraction(video_path, landmarks_path, output_dir, patch_size=32):
             break
         # if count % 6 == 0 and df[' success'][count] == 1:
         # if df[' success'][count] == 1:
-        if count % 6 == 0 and len(df[' success']) > count:
-            if df[' success'][count] == 1:
+        if count % 6 == 0 and len(df['success']) > count:
+            if df['success'][count] == 1:
                 frame = frame[:,:,::-1]
                 frames.append(frame)
                 frame_number.append(count)
@@ -102,7 +102,7 @@ if __name__ == "__main__":
     for video in videos:
         video_path = os.path.join(videos_path, video)
         video = video.replace('.mp4', '')
-        csv_path = os.path.join(landmarks_path, video, video + '.csv')
+        csv_path = os.path.join(landmarks_path, video + '.csv')
         output_path = os.path.join(output_dir, video)
         parameters.append([video_path, csv_path, output_path])
     pool = multiprocessing.Pool()


### PR DESCRIPTION
1. Fixed a key error when reading the status of pandas.read_csv.
2. The landmarks path does not correspond to the output dir in the
landmark extraction step in README. It's confusing to use beacuse this
landmark path is actually a directory containing subfolders for landmarks
of every video. In README its never mentioned the landmarks for each
video should be in a folder whose name is the video name. Therefore, I
changed the rule to find landmarks in extract_facial_regions.py. The
user use a single dir to store all videos' landmarks and use this dir in
cropping and alignment step.